### PR TITLE
Add Geocoder.Providers.Fake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Geocoder
-========
+# Geocoder
 
 [![Build Status](https://github.com/knrz/geocoder/actions/workflows/elixir.yml/badge.svg)](https://github.com/knrz/geocoder/actions/workflows/elixir.yml)
 [![Inline docs](http://inch-ci.org/github/knrz/geocoder.svg?branch=master)](http://inch-ci.org/github/knrz/geocoder)
@@ -15,8 +14,7 @@ A simple, efficient geocoder/reverse geocoder with a built-in cache.
 Is it extensible? Yes.
 **Is it any good?** Absolutely.
 
-Installation
-------------
+## Installation
 
 Keep calm and add `:geocoder` to your `mix.exs` dependencies:
 
@@ -36,8 +34,9 @@ mix deps.get
 
 If you are Elixir < 1.9, you'll need to use a version before `1.0`.
 
-Configuration
--------------
+## Configuration
+
+### Prod & Dev
 
 All configuration below is optional. Sane defaults are set so you don't need to think too hard.
 
@@ -66,11 +65,70 @@ config :geocoder, Geocoder.Worker, [
   httpoison_options: [proxy: "my.proxy.server:3128", proxy_auth: {"username", "password"}]
 ]
 ```
+### Test
+
+To avoid making external requests in the context of the test suite, usage of the [`Fake`](./lib/geocoder/providers/fake.ex) provider is recommended.
+
+The fake provider can be configured by adding a `:data` tuple to the `Geocoder.Worker` configuration as shown below.
+
+The keys of the data map must be in either [regex](https://hexdocs.pm/elixir/Regex.html) or
+[tuple](https://hexdocs.pm/elixir/Tuple.html) format (specifically a `{lat, lng}` style pair of floats).
+
+```elixir
+# config/test.exs
+config :geocoder, :worker,
+  provider: Geocoder.Providers.Fake
+
+config :geocoder, Geocoder.Worker,
+  data: %{
+    ~r/.*New York, NY.*/ => %{
+      lat: 40.7587905,
+      lon: -73.9787755,
+      bounds: %{
+        bottom: 40.7587405,
+        left: -73.9788255,
+        right: -73.9787255,
+        top: 40.7588405,
+      },
+      location: %{
+        city: "New York",
+        country: "United States",
+        country_code: "us",
+        county: "New York County", 
+        formatted_address: "30 Rockefeller Plaza, New York, NY 10112, United States of America",
+        postal_code: "10112",
+        state: "New York",
+        street: "Rockefeller Plaza",
+        street_number: "30"
+      },
+    },
+    {40.7587905, -73.9787755} => %{
+      lat: 40.7587905,
+      lon: -73.9787755,
+      bounds: %{
+        bottom: 40.7587405,
+        left: -73.9788255,
+        right: -73.9787255,
+        top: 40.7588405,
+      },
+      location: %{
+        city: "New York",
+        country: "United States",
+        country_code: "us",
+        county: "New York County", 
+        formatted_address: "30 Rockefeller Plaza, New York, NY 10112, United States of America",
+        postal_code: "10112",
+        state: "New York",
+        street: "Rockefeller Plaza",
+        street_number: "30"
+      },
+    }
+  }
+```
 
 Let's rumble!
 
-Usage
------
+## Usage
 
 ```elixir
 {:ok, coordinates } = Geocoder.call("Toronto, ON")
@@ -85,7 +143,7 @@ You can pass options to the function that will be passed to the geocoder provide
 Geocoder.call(address: "Toronto, ON", language: "es", key: "...", ...)
 ```
 
-You can also change the provider on a per-call basis:
+You can also change the provider on a per-call basis:zx
 
 ```elixir
 {:ok, coordinates } =
@@ -101,8 +159,8 @@ See [here](https://developers.google.com/maps/documentation/geocoding/intro#geoc
 
 And you're done! How simple was that?
 
-Extension
----------
+## Extension
+
 
 Any additional Providers must implement all of the following functions:
 
@@ -113,10 +171,9 @@ reverse_geocode/1
 reverse_geocode_list/1
 ```
 
-Development
------------
+## Development
 
-Right now, `:geocoder` supports three providers (i.e. sources):
+Right now, `:geocoder` supports three external providers (i.e. sources):
 
 * `Geocoder.Providers.GoogleMaps`
 * `Geocoder.Providers.OpenCageData`
@@ -128,10 +185,9 @@ To run the tests for these, and any future providers, you'll want to pass a `PRO
 PROVIDER=google mix test
 ```
 
-By default, the tests run on OpenStreetMaps.
+By default, the tests against the [`Fake`](./lib/geocoder/providers/fake.ex) provider.
 
-Related & Alternative Packages
-------------------------------
+## Related & Alternative Packages
 
 * https://github.com/amotion-city/lib_lat_lon
 * https://github.com/navinpeiris/geoip

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ See [here](https://developers.google.com/maps/documentation/geocoding/intro#geoc
 
 And you're done! How simple was that?
 
+Extension
+---------
+
+Any additional Providers must implement all of the following functions:
+
+```
+geocode/1
+geocode_list/1
+reverse_geocode/1
+reverse_geocode_list/1
+```
+
 Development
 -----------
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can pass options to the function that will be passed to the geocoder provide
 Geocoder.call(address: "Toronto, ON", language: "es", key: "...", ...)
 ```
 
-You can also change the provider on a per-call basis:zx
+You can also change the provider on a per-call basis:
 
 ```elixir
 {:ok, coordinates } =

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,7 @@ config :geocoder, :worker_pool_config,
 
 config :geocoder, Geocoder.Worker,
   data: %{
-    "1991 15th Street, Troy, NY 12180" => %{
+    ~r/.*Troy, NY.*/ => %{
       lat: 0.0,
       lon: 0.0,
       bounds: %{
@@ -24,7 +24,7 @@ config :geocoder, Geocoder.Worker,
         postal_code: "12180",
       }
     },
-    "Dikkelindestraat 46, 9032 Wondelgem, Belgium" => %{
+    ~r/.*Wondelgem, Belgium.*/ => %{
       lat: 51.0775527,
       lon: 3.7074204,
       bounds: %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,69 @@ config :geocoder, :worker_pool_config,
   size: 4,
   max_overflow: 2
 
+config :geocoder, Geocoder.Worker,
+  data: %{
+    "1991 15th Street, Troy, NY 12180" => %{
+      lat: 0.0,
+      lon: 0.0,
+      bounds: %{
+        top: 0.0,
+        right: 0.0,
+        bottom: 0.0,
+        left: 0.0,
+      },
+      location: %{
+        street_number: "1991",
+        street: "15th Street",
+        city: "Troy",
+        county: "Rensselaer County",
+        country_code: "us",
+        postal_code: "12180",
+      }
+    },
+    "Dikkelindestraat 46, 9032 Wondelgem, Belgium" => %{
+      lat: 51.0775527,
+      lon: 3.7074204,
+      bounds: %{
+        bottom: 51.077496,
+        left: 3.7073144,
+        right: 3.7075457,
+        top: 51.0776028,
+      },
+      location: %{
+        city: "Ghent",
+        country: "Belgium",
+        country_code: "be",
+        county: "Gent",
+        formatted_address: "Dikkelindestraat 46, 9032 Ghent, Belgium",
+        postal_code: "9032",
+        state: "East Flanders",
+        street: "Dikkelindestraat",
+        street_number: "46"
+      }
+    },
+    {51.0775264, 3.7073382} => %{
+      lat: 51.0775527,
+      lon: 3.7074204,
+      bounds: %{
+        bottom: 51.077496,
+        left: 3.7073144,
+        right: 3.7075457,
+        top: 51.0776028,
+      },
+      location: %{
+        city: "Ghent",
+        country: "Belgium",
+        country_code: "be",
+        county: "Gent",
+        formatted_address: "Dikkelindestraat 46, 9032 Ghent, Belgium",
+        postal_code: "9032",
+        state: "East Flanders",
+        street: "Dikkelindestraat",
+        street_number: "46"
+      }
+    }
+  }
 case System.get_env("PROVIDER", "openstreetmaps") do
   "google" ->
     config :geocoder, :worker,

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :geocoder, :worker_pool_config,
   size: 4,

--- a/config/config.exs
+++ b/config/config.exs
@@ -67,7 +67,7 @@ config :geocoder, Geocoder.Worker,
       }
     }
   }
-case System.get_env("PROVIDER", "openstreetmaps") do
+case System.get_env("PROVIDER", "fake") do
   "google" ->
     config :geocoder, :worker,
       provider: Geocoder.Providers.GoogleMaps,
@@ -80,4 +80,7 @@ case System.get_env("PROVIDER", "openstreetmaps") do
 
   "openstreetmaps" ->
     config :geocoder, :worker, provider: Geocoder.Providers.OpenStreetMaps
+
+  "fake" ->
+    config :geocoder, :worker, provider: Geocoder.Providers.Fake
 end

--- a/lib/geocoder/providers/fake.ex
+++ b/lib/geocoder/providers/fake.ex
@@ -1,0 +1,52 @@
+defmodule Geocoder.Providers.Fake do
+  use Towel
+
+  def geocode(opts) do
+    look_up_in_config(opts[:address])
+    |> parse_geocode()
+  end
+
+  def geocode_list(opts) do
+    geocode(opts)
+  end
+
+  def reverse_geocode(opts) do
+    look_up_in_config(opts[:latlng])
+    |> parse_geocode()
+  end
+
+  def reverse_geocode_list(opts) do
+    reverse_geocode(opts)
+  end
+
+  defp parse_geocode(nil), do: {:error, nil}
+
+  defp parse_geocode(loaded_config) do
+    coords = geocode_coords(loaded_config)
+    bounds = geocode_bounds(loaded_config[:bounds])
+    location = geocode_location(loaded_config[:location])
+    {:ok, %{coords | bounds: bounds, location: location}}
+  end
+
+  defp geocode_coords(%{lat: lat, lon: lon}) do
+    %Geocoder.Coords{lat: lat, lon: lon}
+  end
+
+  defp geocode_coords(_), do: %Geocoder.Coords{}
+
+  defp geocode_bounds(%{top: north, right: east, bottom: south, left: west}) do
+    %Geocoder.Bounds{top: north, right: east, bottom: south, left: west}
+  end
+
+  defp geocode_bounds(_), do: %Geocoder.Bounds{}
+
+  defp geocode_location(nil), do: %Geocoder.Location{}
+
+  defp geocode_location(location_attrs) do
+    Map.merge(%Geocoder.Location{}, location_attrs)
+  end
+
+  defp look_up_in_config(key) do
+    Geocoder.worker_config()[:data][key]
+  end
+end

--- a/lib/geocoder/providers/fake.ex
+++ b/lib/geocoder/providers/fake.ex
@@ -1,25 +1,29 @@
 defmodule Geocoder.Providers.Fake do
   use Towel
 
+  @error {:error, nil}
+
   def geocode(opts) do
-    look_up_in_config(opts[:address])
+    geocode_from_config(opts[:address])
     |> parse_geocode()
   end
 
   def geocode_list(opts) do
-    geocode(opts)
+    opts
+    |> Enum.map(fn x -> geocode(x) end)
   end
 
   def reverse_geocode(opts) do
-    look_up_in_config(opts[:latlng])
+    reverse_geocode_from_config(opts[:latlng])
     |> parse_geocode()
   end
 
   def reverse_geocode_list(opts) do
-    reverse_geocode(opts)
+    opts
+    |> Enum.map(fn x -> reverse_geocode(x) end)
   end
 
-  defp parse_geocode(nil), do: {:error, nil}
+  defp parse_geocode(nil), do: @error
 
   defp parse_geocode(loaded_config) do
     coords = geocode_coords(loaded_config)
@@ -46,7 +50,24 @@ defmodule Geocoder.Providers.Fake do
     Map.merge(%Geocoder.Location{}, location_attrs)
   end
 
-  defp look_up_in_config(key) do
-    Geocoder.worker_config()[:data][key]
+  def get_worker_config() do
+    Geocoder.worker_config()
+    |> Keyword.get(:data, %{})
+  end
+
+  def geocode_from_config(key) do
+    {_, value} = get_worker_config()
+      |> Enum.filter(fn {k, _} -> is_struct(k, Regex) end)
+      |> Enum.find(@error, fn {regex, _} -> String.match?(key, regex) end)
+
+    value
+  end
+
+  def reverse_geocode_from_config(latlng) do
+    {_, value} = get_worker_config()
+      |> Enum.filter(fn {k, _} -> is_tuple(k) end)
+      |> Enum.find(@error, fn {tuple, _} -> tuple == latlng end)
+
+    value
   end
 end

--- a/lib/geocoder/providers/fake.ex
+++ b/lib/geocoder/providers/fake.ex
@@ -4,23 +4,31 @@ defmodule Geocoder.Providers.Fake do
   @error {:error, nil}
 
   def geocode(opts) do
-    geocode_from_config(opts[:address])
-    |> parse_geocode()
+    coords = geocode_from_config(opts[:address])
+      |> parse_geocode()
+
+    {:ok, coords}
   end
 
   def geocode_list(opts) do
-    opts
-    |> Enum.map(fn x -> geocode(x) end)
+    coords = geocode_from_config(opts[:address])
+      |> parse_geocode()
+
+    {:ok, List.wrap(coords)}
   end
 
   def reverse_geocode(opts) do
-    reverse_geocode_from_config(opts[:latlng])
-    |> parse_geocode()
+    coords = reverse_geocode_from_config(opts[:latlng])
+      |> parse_geocode()
+
+    {:ok, coords}
   end
 
   def reverse_geocode_list(opts) do
-    opts
-    |> Enum.map(fn x -> reverse_geocode(x) end)
+    coords = reverse_geocode_from_config(opts[:latlng])
+      |> parse_geocode()
+
+    {:ok, List.wrap(coords)}
   end
 
   defp parse_geocode(nil), do: @error
@@ -29,7 +37,7 @@ defmodule Geocoder.Providers.Fake do
     coords = geocode_coords(loaded_config)
     bounds = geocode_bounds(loaded_config[:bounds])
     location = geocode_location(loaded_config[:location])
-    {:ok, %{coords | bounds: bounds, location: location}}
+    %{coords | bounds: bounds, location: location}
   end
 
   defp geocode_coords(%{lat: lat, lon: lon}) do

--- a/test/geocoder_test.exs
+++ b/test/geocoder_test.exs
@@ -1,5 +1,5 @@
 defmodule GeocoderTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   setup do
     # there's some state we need to clear before each test run
@@ -8,7 +8,7 @@ defmodule GeocoderTest do
     {:ok, _} = Supervisor.restart_child(Geocoder.Supervisor, Geocoder.Store)
 
     # OpenStreetData is rate-limited at 1rps. Let's ensure our tests don't break that rate limit.
-    System.get_env("PROVIDER") != "fake" && Process.sleep(1_000)
+    System.get_env("PROVIDER", "fake") != "fake" && Process.sleep(1_000)
 
     :ok
   end

--- a/test/geocoder_test.exs
+++ b/test/geocoder_test.exs
@@ -8,7 +8,7 @@ defmodule GeocoderTest do
     {:ok, _} = Supervisor.restart_child(Geocoder.Supervisor, Geocoder.Store)
 
     # OpenStreetData is rate-limited at 1rps. Let's ensure our tests don't break that rate limit.
-    Process.sleep(1_000)
+    System.get_env("PROVIDER") != "fake" && Process.sleep(1_000)
 
     :ok
   end


### PR DESCRIPTION
Resolves #13

Adds configuration options similar to [Geolix.Adapter.Fake](https://github.com/elixir-geolix/geolix#fake-adapter) for configuring test mocks for calls to Geocoder.

I would definitely appreciate advice on approaches around the test suite changes as well as prime targets for refactoring.