### PR TITLE
Increase precision default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ config :geocoder, Geocoder.Worker, [
   httpoison_options: [proxy: "my.proxy.server:3128", proxy_auth: {"username", "password"}]
 ]
 ```
+
+If you want to change the cache precision (defaults to `6`):
+
+```elixir
+config :geocoder, Geocoder.Store, precision: 6
+```
 ### Test
 
 To avoid making external requests in the context of the test suite, usage of the [`Fake`](./lib/geocoder/providers/fake.ex) provider is recommended.

--- a/lib/geocoder/store.ex
+++ b/lib/geocoder/store.ex
@@ -26,7 +26,7 @@ defmodule Geocoder.Store do
   # GenServer API
   def init(args), do: {:ok, args}
 
-  @defaults [precision: 4]
+  @defaults [precision: 6]
   def start_link(opts \\ []) do
     opts = Keyword.merge(@defaults, opts)
     GenServer.start_link(__MODULE__, {%{}, %{}, opts}, name: name())


### PR DESCRIPTION
PR based on #89 increasing the default precision to `6` and documenting the option in the readme.