### PR TITLE
Add partial_match on Geocoder Response

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -65,6 +65,28 @@ config :geocoder, Geocoder.Worker,
         street: "Dikkelindestraat",
         street_number: "46"
       }
+    },
+    ~r/.*São Paulo, Brazil.*/ => %{
+      lat: -23.473875,
+      lon: -46.6088782,
+      bounds: %{
+        bottom: nil,
+        left: nil,
+        right: nil,
+        top: nil
+      },
+      location: %{
+        city: nil,
+        country: "Brazil",
+        country_code: "BR",
+        county: "São Paulo",
+        formatted_address: "Travessa Mário Antônio Correia, 80 - Tucuruvi, São Paulo - SP, 02342-170, Brazil",
+        postal_code: "02342-170",
+        state: "São Paulo",
+        street: "Travessa Mário Antônio Correia",
+        street_number: "80"
+      },
+      partial_match: true
     }
   }
 

--- a/lib/geocoder/providers/google_maps.ex
+++ b/lib/geocoder/providers/google_maps.ex
@@ -48,7 +48,7 @@ defmodule Geocoder.Providers.GoogleMaps do
     coords = geocode_coords(response)
     bounds = geocode_bounds(response)
     location = geocode_location(response)
-    partial_match = geocode_partial_match(response)
+    partial_match = response["partial_match"]
     %{coords | bounds: bounds, location: location, partial_match: partial_match}
   end
 
@@ -134,8 +134,6 @@ defmodule Geocoder.Providers.GoogleMaps do
     |> Enum.map(map)
     |> Enum.reduce(location, reduce)
   end
-
-  defp geocode_partial_match(response), do: response["partial_match"] || false
 
   defp request_all(path, params) do
     params =

--- a/lib/geocoder/providers/google_maps.ex
+++ b/lib/geocoder/providers/google_maps.ex
@@ -48,7 +48,8 @@ defmodule Geocoder.Providers.GoogleMaps do
     coords = geocode_coords(response)
     bounds = geocode_bounds(response)
     location = geocode_location(response)
-    %{coords | bounds: bounds, location: location}
+    partial_match = geocode_partial_match(response)
+    %{coords | bounds: bounds, location: location, partial_match: partial_match}
   end
 
   defp parse_reverse_geocode(response) do
@@ -133,6 +134,8 @@ defmodule Geocoder.Providers.GoogleMaps do
     |> Enum.map(map)
     |> Enum.reduce(location, reduce)
   end
+
+  defp geocode_partial_match(response), do: response["partial_match"] || false
 
   defp request_all(path, params) do
     params =

--- a/lib/geocoder/structs/coords.ex
+++ b/lib/geocoder/structs/coords.ex
@@ -2,5 +2,6 @@ defmodule Geocoder.Coords do
   defstruct lat: nil,
             lon: nil,
             bounds: %Geocoder.Bounds{},
-            location: %Geocoder.Location{}
+            location: %Geocoder.Location{},
+            partial_match: nil
 end

--- a/test/geocoder_test.exs
+++ b/test/geocoder_test.exs
@@ -31,6 +31,11 @@ defmodule GeocoderTest do
     assert_belgium(coords)
   end
 
+  test "An address that returns a partial match" do
+    {:ok, coords} = Geocoder.call("Rua não existente, 101, São Paulo, Brazil")
+    assert_sao_paulo(coords)
+  end
+
   test "properly handles call-specific provider and key configurations" do
     {:error, "missing API key"} =
       Geocoder.call("1991 15th Street, Troy, NY 12180", provider: Geocoder.Providers.OpenCageData)
@@ -96,5 +101,16 @@ defmodule GeocoderTest do
     assert location.formatted_address |> String.match?(~r/Belgium/)
     assert lat |> Float.round(2) == 51.08
     assert lon |> Float.round(2) == 3.71
+  end
+
+  defp assert_sao_paulo(%{location: location, partial_match: partial_match}) do
+    assert location.country == "Brazil"
+    assert location.country_code |> String.upcase() == "BR"
+    assert location.county == "São Paulo"
+    assert location.formatted_address == "Travessa Mário Antônio Correia, 80 - Tucuruvi, São Paulo - SP, 02342-170, Brazil"
+    assert location.postal_code == "02342-170"
+    assert location.street == "Travessa Mário Antônio Correia"
+    assert location.street_number == "80"
+    assert partial_match == true
   end
 end


### PR DESCRIPTION
## Objective
Add a parameter to know if a result is a partial match. This could be very useful since some applications (my case) needs the exact result for a location and currently there is no way to know if it is a partial match or not.